### PR TITLE
Implement URL parsing for ticket fetcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This pack provides three commands: `CommentIssue`, `IssueInfo` and `CreateIssue`
 ### issueInfo command
 This command returns information about a specific issue.
 #### Input
-This commands input is the id of the desired issue. The issue can either be a URL with an issueId base or an issueId in string representation.
+This command's input is the id of the desired issue. The issue can either be a URL with an issueId base or an issueId in string representation.
 E.g
 ```
 "input": "TEST-123",
@@ -35,7 +35,7 @@ E.g
 ```
 
 Because slack automatically places embeded URLs in between `< >` tags, then the following is also accepted:
-`"input": "<http://foo.bar/TEST-123>" 
+`"input": "<http://foo.bar/TEST-123>"`
 #### Output
 This command can either return an `Info` event or an `InfoFailure` event.
 ##### Info event

--- a/README.md
+++ b/README.md
@@ -27,10 +27,15 @@ This pack provides three commands: `CommentIssue`, `IssueInfo` and `CreateIssue`
 ### issueInfo command
 This command returns information about a specific issue.
 #### Input
-This commands input is the id of the desired issue:
+This commands input is the id of the desired issue. The issue can either be a URL with an issueId base or an issueId in string representation.
+E.g
 ```
-"input" : "TEST-123",
+"input": "TEST-123",
+"input": "http://foo.bar/TEST-123"
 ```
+
+Because slack automatically places embeded URLs in between `< >` tags, then the following is also accepted:
+`"input": "<http://foo.bar/TEST-123>" 
 #### Output
 This command can either return an `Info` event or an `InfoFailure` event.
 ##### Info event

--- a/client/jira.go
+++ b/client/jira.go
@@ -117,12 +117,11 @@ func GetIssueInfo(issueId string) (domain.Issue, error) {
 		return domain.Issue{}, fmt.Errorf("issueId=%s : statusCode=%d", issueId, statusCode)
 	}
 	if err != nil {
-		return domain.Issue{}, err
+		return domain.Issue{}, fmt.Errorf("issueId=%s : err=%s", issueId, err)
 	}
 
 	return issue, nil
 }
-
 
 func CreateIssue(project, issueType, title string) (domain.Issue, error) {
 	var issue domain.Issue

--- a/client/jira.go
+++ b/client/jira.go
@@ -114,16 +114,15 @@ func GetIssueInfo(issueId string) (domain.Issue, error) {
 
 	statusCode, err := SendRequest(request, &issue)
 	if statusCode != http.StatusOK {
-		err = fmt.Errorf("issueId=%s : statusCode=%d", issueId, statusCode)
-		return domain.Issue{}, err
+		return domain.Issue{}, fmt.Errorf("issueId=%s : statusCode=%d", issueId, statusCode)
 	}
 	if err != nil {
-		err = fmt.Errorf("issueId=%s : err=%v", issueId, err)
 		return domain.Issue{}, err
 	}
 
 	return issue, nil
 }
+
 
 func CreateIssue(project, issueType, title string) (domain.Issue, error) {
 	var issue domain.Issue

--- a/command/info.go
+++ b/command/info.go
@@ -23,45 +23,65 @@ import (
 	"github.com/ExpediaGroup/flyte-jira/domain"
 	"github.com/HotelsDotCom/flyte-client/flyte"
 	"log"
+	"net/url"
+	"path"
+	"strings"
 )
 
-var IssueInfoCommand = flyte.Command{
-	Name:         "IssueInfo",
-	OutputEvents: []flyte.EventDef{infoEventDef, infoFailureEventDef},
-	Handler:      infoHandler,
-}
+var (
+	IssueInfoCommand = flyte.Command{
+		Name:         "IssueInfo",
+		OutputEvents: []flyte.EventDef{infoEventDef, infoFailureEventDef},
+		Handler:      infoHandler,
+	}
+
+	infoEventDef = flyte.EventDef{
+		Name: "Info",
+	}
+
+	infoFailureEventDef = flyte.EventDef{
+		Name: "InfoFailure",
+	}
+)
+
+type (
+	infoSuccessPayload struct {
+		Id          string `json:"id"`
+		Summary     string `json:"summary"`
+		Status      string `json:"status"`
+		Description string `json:"description"`
+		Assignee    string `json:"assignee"`
+	}
+
+	infoFailurePayload struct {
+		Id    string `json:"id"`
+		Error string `json:"error"`
+	}
+)
 
 func infoHandler(input json.RawMessage) flyte.Event {
-	var id string
-	issue := domain.Issue{}
-
-	if err := json.Unmarshal(input, &id); err != nil {
-		err := fmt.Errorf("Could not marshal issue id: %s", err)
-		log.Println(err)
-		return newInfoFailureEvent(err.Error(), "unkown")
-	}
-
-	issue, err := client.GetIssueInfo(id)
+	issueId, err := parseInput(input)
 	if err != nil {
-		err := fmt.Errorf("Could not get info: %v", err)
-		log.Println(err)
-		return newInfoFailureEvent(err.Error(), id)
+		log.Printf("Error parsing input for IssueInfo: %s", err)
+		return newInfoFailureEvent(err.Error(), issueId)
 	}
+
+	issue, err := client.GetIssueInfo(issueId)
+	if err != nil {
+		err = fmt.Errorf("could not get info: %v", err)
+		log.Print(err)
+		return newInfoFailureEvent(err.Error(), issueId)
+	}
+
 	return newInfoEvent(issue)
-}
-
-var infoEventDef = flyte.EventDef{
-	Name: "Info",
-}
-
-var infoFailureEventDef = flyte.EventDef{
-	Name: "InfoFailure",
 }
 
 func newInfoFailureEvent(err, id string) flyte.Event {
 	return flyte.Event{
 		EventDef: infoFailureEventDef,
-		Payload:  infoFailurePayload{id, err},
+		Payload: infoFailurePayload{
+			id,
+			err},
 	}
 }
 
@@ -78,15 +98,35 @@ func newInfoEvent(t domain.Issue) flyte.Event {
 	}
 }
 
-type infoSuccessPayload struct {
-	Id          string `json:"id"`
-	Summary     string `json:"summary"`
-	Status      string `json:"status"`
-	Description string `json:"description"`
-	Assignee    string `json:"assignee"`
+func parseInput(input json.RawMessage) (string, error) {
+	log.Printf("Input raw: %s", input)
+	var in string
+	if err := json.Unmarshal(input, &in); err != nil {
+		return "", err
+	}
+
+	// Slack places URLs between <> tags, if using it as the input method
+	// then the tags need to be stripped first before processing the rest
+	if strings.Contains(in, "<") {
+		in = in[1:len(in)-1]
+	}
+
+	if !hasURLFormat(in) {
+		log.Printf("Input is not url: %s", in)
+		return in, nil
+	}
+
+	id := path.Base(in)
+	if id == "." || id == "\\" {
+		return "", fmt.Errorf("url format not supported for issueId: %s", in)
+	}
+
+	log.Printf("URL Base: %s", id)
+	return id, nil
 }
 
-type infoFailurePayload struct {
-	Id    string `json:"id"`
-	Error string `json:"error"`
+// Credit: https://stackoverflow.com/a/55551215
+func hasURLFormat(s string) bool {
+	u, err := url.Parse(s)
+	return err == nil && u.Scheme != "" && u.Host != "" && u.Path != ""
 }

--- a/command/info_test.go
+++ b/command/info_test.go
@@ -17,32 +17,67 @@ limitations under the License.
 package command
 
 import (
+	"fmt"
 	"github.com/ExpediaGroup/flyte-jira/client"
 	"github.com/ExpediaGroup/flyte-jira/domain"
 	"net/http"
+	"path"
 	"reflect"
 	"testing"
 )
 
 type infoTest struct {
-	name string
-	rawJson string
+	name       string
+	rawJson    string
+	expIssueId string
 }
 
 func TestGetInfoWorkingAsExpected(t *testing.T) {
+	initialFunc := client.SendRequest
+	defer func(){ client.SendRequest = initialFunc}()
+	expectedIssueId := ""
 	client.SendRequest = func(request *http.Request, responseBody interface{}) (int, error) {
+		reqPath := request.URL.Path
+		issueId := path.Base(reqPath)
+		if issueId != expectedIssueId {
+			return http.StatusBadRequest, fmt.Errorf("expected issueId %s got %s", "DEVEX-553", issueId)
+		}
 		return http.StatusOK, nil
 	}
 
-	testCases := []infoTest {
-		{"test-normal-input", `"Test"`},
-		{"test-url-input", `"http://test123.com/Test"`},
-		{"test-slack-url-input", `"<http://test123.com/Test>"`},
+	testCases := []infoTest{
+		{"test-normal-input",
+			`"DEVEX-553"`,
+			"DEVEX-553",
+		},
+		{
+			"test-url-input",
+			`"http://test123.com/TeSt-75122"`,
+			"TeSt-75122",
+		},
+		{
+			"test-url-without-valid-base",
+			`"https://jira.expedia.biz/browse/ELF-21462?jql=project%20%3D%20ELS%20AND%20resolution%20%3D%20Unresolved%20AND%20text%20~%20%22symantec%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC"`,
+			"ELF-21462",
+		},
+		{"test-url-with-nested-path",
+			`"https://jira.expedia.biz/servicedesk/customer/portal/518/FOOBARFOOBAR-7773"`,
+			"FOOBARFOOBAR-7773",
+		},
+		{"test-external-url",
+			`"https://jira.expedia.biz/browse/TEST-221"`,
+			"TEST-221",
+		},
+		{"test-slack-url-input",
+			`"<http://test123.com/ELS-790>"`,
+			"ELS-790",
+		},
 	}
 
 	for _, tCase := range testCases {
 		t.Run(tCase.name, func(t *testing.T) {
 			in := tCase.rawJson
+			expectedIssueId = tCase.expIssueId
 			event := infoHandler([]byte(in))
 
 			expectedEvent := newInfoEvent(domain.Issue{})
@@ -54,14 +89,16 @@ func TestGetInfoWorkingAsExpected(t *testing.T) {
 }
 
 func TestGetInfoFailure(t *testing.T) {
+	initialFunc := client.SendRequest
+	defer func(){ client.SendRequest = initialFunc}()
 	client.SendRequest = func(request *http.Request, responseBody interface{}) (int, error) {
 		return http.StatusBadRequest, nil
 	}
-	input := toJson("Test", t)
-	actualEvent := infoHandler(input)
+	input := `"Test-123"`
+	actualEvent := infoHandler([]byte(input))
 
 	// Issue empty because it's populated in Send request
-	expectedEvent := newInfoFailureEvent("could not get info: issueId=Test : statusCode=400", "Test")
+	expectedEvent := newInfoFailureEvent("Test-123", fmt.Errorf("issueId=%s : statusCode=%d", "Test-123", 400))
 	if !reflect.DeepEqual(actualEvent, expectedEvent) {
 		t.Errorf("Expected: %v but got: %v", expectedEvent, actualEvent)
 	}

--- a/command/info_test.go
+++ b/command/info_test.go
@@ -34,7 +34,7 @@ type infoTest struct {
 
 func TestGetInfoWorkingAsExpected(t *testing.T) {
 	initialFunc := client.SendRequest
-	defer func(){ client.SendRequest = initialFunc}()
+	defer func() { client.SendRequest = initialFunc }()
 	expectedIssueId := ""
 	client.SendRequest = func(request *http.Request, responseBody interface{}) (int, error) {
 		reqPath := request.URL.Path
@@ -90,7 +90,7 @@ func TestGetInfoWorkingAsExpected(t *testing.T) {
 
 func TestGetInfoFailure(t *testing.T) {
 	initialFunc := client.SendRequest
-	defer func(){ client.SendRequest = initialFunc}()
+	defer func() { client.SendRequest = initialFunc }()
 	client.SendRequest = func(request *http.Request, responseBody interface{}) (int, error) {
 		return http.StatusBadRequest, nil
 	}


### PR DESCRIPTION
Adds the ability to send a URL representation of the Jira ticket, provided the base of the URL has the issueId.

E.g
`https://jira.com/example-board/EXAMPLE-TICKET`
`https://foo.bar/EXAMPLE-TICKET`

etc.

Signed-off-by: Matei207 <madavid@expediagroup.com>