### PR TITLE
Add link capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To build and run from docker
 * All of these environment variables need to be set
 
 ## Commands
-This pack provides three commands: `CommentIssue`, `IssueInfo` and `CreateIssue`.
+This pack provides the following commands: `CommentIssue`, `IssueInfo`, `CreateIssue`, `IssueAssign`, `IssueCreateLink`, `IssueGetLink`, `IssueDeleteLink`
 ### issueInfo command
 This command returns information about a specific issue.
 #### Input
@@ -169,7 +169,7 @@ This returns the error if the jql query is not valid. It contains the values giv
     "error": "Could not search for issues: statusCode=400"
 }
 ```
-
+---
 [issue-assign]: https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/#api/2/issue-assign
 ### IssueAssign command
 Assign a user to a JIRA issue
@@ -204,3 +204,67 @@ If the assignment is unsuccessful, an `assignFailureEvent` will come back with a
   "error": "Unauthorised"
 }
 ```
+
+---
+### Links
+
+Jira offers the possibility to manage links between issues. The commands that are available to do so are `IssueGetLink`, `IssueDeleteLink` and `IssueCreateLink`. While their functionality is self-explanatory, the input/output varies depending on the operation.
+
+The two event types in the case of links are:
+1. `Link` --> propagated on success
+2. `LinkFailure` --> propagated on failure
+
+#### IssueGetLink
+
+will return a link object that links two issues. 
+
+#### Input:
+The input is a `json` object with a `linkId` field, where the `linkId` is id of the respective link object. Generally, those ids can be obtained by looking at a card information (`IssueInfo` now supports link information!).
+```json
+{
+ "linkId": "12351245"
+}
+```
+
+#### Output:
+In case of a success, the output will contain the link information:
+```json
+{
+ "inwardIssue": "<issue-key>",
+ "outwardIssue": "<issue-key>",
+ "linkType": {
+   "Name": "Depends"
+  },
+ "Comment": "Link related issues!" 
+}
+```
+
+#### IssueCreateLink
+Based on 2 project keys and and a link type, create a link with that type between the 2 issues.
+
+#### Input:
+```json
+{
+ "inwardIssue": "<issue-key>",
+  "outwardIssue": "<issue-key>",
+  "linkType": "<type>",
+}
+```
+
+#### Output:
+The output is the initial request or a failure event if unsuccessful.
+
+#### IssueDeleteLink
+Based on a `linkId`, the link between 2 issues is deleted.
+
+#### Input:
+```json
+{
+ "linkId": "12341234"
+}
+```
+
+#### Output:
+The initial request if successful or a failure event if unsuccessful.
+
+---

--- a/client/jira.go
+++ b/client/jira.go
@@ -75,6 +75,23 @@ type (
 	AssignRequest struct {
 		Name string `json:"name,omitempty"`
 	}
+
+	LinkIssueRequest struct {
+		LinkType IssueLink `json:"type"`
+		Inward   LinkIssue `json:"inwardIssue"`
+		Outward  LinkIssue `json:"outwardIssue"`
+		Comment  `json:"comment"`
+	}
+
+	LinkIssue struct {
+		Key string `json:"key"`
+	}
+
+	IssueLink struct {
+		Name    string `json:"name"`
+		Inward  string `json:"inward,omitempty"`
+		Outward string `json:"outward,omitempty"`
+	}
 )
 
 func CommentIssue(issueId, comment string) (domain.Issue, error) {
@@ -209,6 +226,80 @@ func AssignIssue(issueId, username string) error {
 	return err
 }
 
+func LinkIssues(inwardKey, outwardKey, linkType string) error {
+	path := "/rest/api/2/issueLink"
+	linkReq := LinkIssueRequest{
+		LinkType: IssueLink{Name: linkType},
+		Inward:   LinkIssue{inwardKey},
+		Outward:  LinkIssue{outwardKey},
+		Comment:  Comment{"Link related issues!"},
+	}
+	b, err := json.Marshal(linkReq)
+	if err != nil {
+		return err
+	}
+
+	httpReq, err := constructPostRequest(path, string(b))
+	if err != nil {
+		return err
+	}
+
+	httpCode, err := SendRequestWithoutResp(httpReq)
+	if err != nil {
+		return err
+	}
+
+	return checkHttpCode(httpCode, linkReq.Body)
+}
+
+func GetLink(linkId string) (*LinkIssueRequest, error) {
+	path := fmt.Sprintf("/rest/api/2/issueLink/%s", linkId)
+	httpReq, err := constructGetRequest(path)
+	if err != nil {
+		return nil, err
+	}
+
+	link := &LinkIssueRequest{}
+	httpCode, err := SendRequest(httpReq, &link)
+
+	return link, checkHttpCode(httpCode, linkId)
+}
+
+//TODO: get rid of all of those separate construct methods...
+func DeleteLink(linkId string) error {
+	path := fmt.Sprintf("/rest/api/2/issueLink/%s", linkId)
+	httpReq, err := constructDeleteRequest(path)
+	if err != nil {
+		return err
+	}
+
+	httpCode, err := SendRequestWithoutResp(httpReq)
+	return checkHttpCode(httpCode, linkId)
+}
+
+//TODO: change error msg to be more generic and use in other funcs
+func checkHttpCode(httpCode int, in string) error {
+	if 200 <= httpCode && httpCode <= 208 {
+		return nil
+	}
+
+	var err error
+	switch httpCode {
+	case http.StatusBadRequest:
+		err = fmt.Errorf("failed to create issue with comment %s", in)
+	case http.StatusUnauthorized:
+		err = errors.New("invalid permission to link issues")
+	case http.StatusInternalServerError:
+		err = errors.New("error occurred when creating link or comment")
+	case http.StatusNotFound:
+		err = errors.New("could not find issue or invalid link type specified")
+	default:
+		err = fmt.Errorf("unsupported status code %d found", httpCode)
+	}
+
+	return err
+}
+
 func newCreateIssueRequest(projectKey, issueType, summary string) IssueRequest {
 	project := ProjectRequest{projectKey}
 	issue := IssueTypeRequest{issueType}
@@ -228,6 +319,20 @@ func newSearchRequestBody(query string, startIndex int, maxResults int) SearchRe
 
 func constructGetRequest(path string) (*http.Request, error) {
 	request, err := http.NewRequest(http.MethodGet, getUrl(path), nil)
+	if err != nil {
+		return request, err
+	}
+
+	request.Header.Set("Accept", "application/json")
+	if JiraConfig.Username != "" {
+		request.SetBasicAuth(JiraConfig.Username, JiraConfig.Password)
+	}
+
+	return request, err
+}
+
+func constructDeleteRequest(path string) (*http.Request, error) {
+	request, err := http.NewRequest(http.MethodDelete, getUrl(path), nil)
 	if err != nil {
 		return request, err
 	}
@@ -261,7 +366,7 @@ func constructPutRequest(path, data string) (*http.Request, error) {
 		return request, err
 	}
 
-	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Content-LinkType", "application/json")
 	request.Header.Set("Accept", "application/json")
 
 	if JiraConfig.Username != "" {

--- a/command/info.go
+++ b/command/info.go
@@ -73,6 +73,7 @@ func infoHandler(input json.RawMessage) flyte.Event {
 		return newInfoFailureEvent(issueId, err)
 	}
 
+	log.Printf("Issue links %v", issue.Fields.Links)
 	return newInfoEvent(issue)
 }
 

--- a/command/info.go
+++ b/command/info.go
@@ -18,11 +18,12 @@ package command
 
 import (
 	"encoding/json"
+	"log"
+	"regexp"
+
 	"github.com/ExpediaGroup/flyte-jira/client"
 	"github.com/ExpediaGroup/flyte-jira/domain"
 	"github.com/HotelsDotCom/flyte-client/flyte"
-	"log"
-	"regexp"
 )
 
 var (
@@ -73,7 +74,6 @@ func infoHandler(input json.RawMessage) flyte.Event {
 		return newInfoFailureEvent(issueId, err)
 	}
 
-	log.Printf("Issue links %v", issue.Fields.Links)
 	return newInfoEvent(issue)
 }
 

--- a/command/issue_link.go
+++ b/command/issue_link.go
@@ -1,0 +1,115 @@
+package command
+
+import (
+	"encoding/json"
+	"github.com/ExpediaGroup/flyte-jira/client"
+	"github.com/HotelsDotCom/flyte-client/flyte"
+	"log"
+)
+
+var (
+	IssueCreateLinkCommand = flyte.Command{
+		Name:         "IssueCreateLink",
+		OutputEvents: []flyte.EventDef{linkEventDef, linkFailureEventDef},
+		Handler:      issueCreateLinkHandler,
+	}
+
+	IssueGetLinkCommand = flyte.Command{
+		Name:         "IssueGetLink",
+		OutputEvents: []flyte.EventDef{linkEventDef, linkFailureEventDef},
+		Handler:      issueGetLinkHandler,
+	}
+
+	IssueDeleteLinkCommand = flyte.Command{
+		Name:         "IssueDeleteLink",
+		OutputEvents: []flyte.EventDef{linkEventDef, linkFailureEventDef},
+		Handler:      issueDeleteLinkHandler,
+	}
+
+	linkEventDef = flyte.EventDef{
+		Name: "Link",
+	}
+
+	linkFailureEventDef = flyte.EventDef{
+		Name: "LinkFailure",
+	}
+)
+
+type (
+	linkFailurePayload struct {
+		linkRequest
+		Error string `json:"error"`
+	}
+
+	linkRequest struct {
+		LinkId       string `json:"linkId,omitempty"`
+		InwardIssue  string `json:"inwardIssue,omitempty"`
+		OutwardIssue string `json:"outwardIssue,omitempty"`
+		LinkType     string `json:"linkType,omitempty"`
+	}
+)
+
+func issueGetLinkHandler(input json.RawMessage) flyte.Event {
+	req := linkRequest{}
+	if err := json.Unmarshal(input, &req); err != nil {
+		log.Printf("Error unmarshaling Issue Link Request [%s]: %s", input, err)
+		return newLinkFailureEvent(req, err)
+	}
+
+	resp, err := client.GetLink(req.LinkId)
+	if err != nil {
+		log.Printf("Error fetching link %s: %s", req.LinkId, err)
+		return newLinkFailureEvent(req, err)
+	}
+
+	return flyte.Event{
+		EventDef: linkEventDef,
+		Payload:  resp,
+	}
+}
+
+func issueCreateLinkHandler(input json.RawMessage) flyte.Event {
+	req := linkRequest{}
+	if err := json.Unmarshal(input, &req); err != nil {
+		log.Printf("Error unmarshaling Issue Link Request [%s]: %s", input, err)
+		return newLinkFailureEvent(req, err)
+	}
+
+	if err := client.LinkIssues(req.InwardIssue, req.OutwardIssue, req.LinkType); err != nil {
+		log.Printf("Error linking Issue %s to Issue %s with type %s: %s", req.InwardIssue, req.OutwardIssue, req.LinkType, err)
+		return newLinkFailureEvent(req, err)
+	}
+
+	return flyte.Event{
+		EventDef: linkEventDef,
+		Payload:  req,
+	}
+}
+
+func issueDeleteLinkHandler(input json.RawMessage) flyte.Event {
+	req := linkRequest{}
+	if err := json.Unmarshal(input, &req); err != nil {
+		log.Printf("Error unmarshaling Issue Link Request [%s]: %s", input, err)
+		return newLinkFailureEvent(req, err)
+	}
+
+	if err := client.DeleteLink(req.LinkId); err != nil {
+		log.Printf("Error removing link %s: %s", req.LinkId, err)
+		return newLinkFailureEvent(req, err)
+	}
+
+	return flyte.Event{
+		EventDef: linkEventDef,
+		Payload:  req,
+	}
+}
+
+func newLinkFailureEvent(request linkRequest, err error) flyte.Event {
+	return flyte.Event{
+		EventDef: linkFailureEventDef,
+		Payload: linkFailurePayload{
+			request,
+			err.Error(),
+		},
+	}
+}

--- a/command/issue_link_test.go
+++ b/command/issue_link_test.go
@@ -3,25 +3,24 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ExpediaGroup/flyte-jira/client"
-	"github.com/HotelsDotCom/flyte-client/flyte"
 	"io/ioutil"
 	"net/http"
 	"path"
 	"reflect"
 	"testing"
+
+	"github.com/ExpediaGroup/flyte-jira/client"
+	"github.com/HotelsDotCom/flyte-client/flyte"
 )
 
 func TestLinkCreateIsSuccessful(t *testing.T) {
 	initialFunc := client.SendRequestWithoutResp
 	defer func() { client.SendRequestWithoutResp = initialFunc }()
-	in := []byte(`
-    {
-	"inwardIssue": "TEST-123",
-    "outwardIssue": "Test-321",
-    "linkType": "Depends"
-    }
-	`)
+	in := []byte(`{
+        "inwardIssue": "TEST-123",
+        "outwardIssue": "Test-321",
+        "linkType": "Depends"
+        }`)
 
 	expHttpReq := client.LinkIssueRequest{
 		LinkType: client.IssueLink{Name: "Depends"},

--- a/command/issue_link_test.go
+++ b/command/issue_link_test.go
@@ -1,0 +1,131 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/ExpediaGroup/flyte-jira/client"
+	"github.com/HotelsDotCom/flyte-client/flyte"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"reflect"
+	"testing"
+)
+
+func TestLinkCreateIsSuccessful(t *testing.T) {
+	initialFunc := client.SendRequestWithoutResp
+	defer func() { client.SendRequestWithoutResp = initialFunc }()
+	in := []byte(`
+    {
+	"inwardIssue": "TEST-123",
+    "outwardIssue": "Test-321",
+    "linkType": "Depends"
+    }
+	`)
+
+	expHttpReq := client.LinkIssueRequest{
+		LinkType: client.IssueLink{Name: "Depends"},
+		Inward:   client.LinkIssue{"TEST-123"},
+		Outward:  client.LinkIssue{"Test-321"},
+		Comment:  client.Comment{"Link related issues!"},
+	}
+	client.SendRequestWithoutResp = func(request *http.Request) (int, error) {
+		b, err := ioutil.ReadAll(request.Body)
+		if err != nil {
+			return 400, err
+		}
+
+		body := client.LinkIssueRequest{}
+		if err := json.Unmarshal(b, &body); err != nil {
+			return 400, err
+		}
+
+		if !reflect.DeepEqual(expHttpReq, body) {
+			return http.StatusNotFound, fmt.Errorf("expHttpRequest: %v actual: %v", expHttpReq, body)
+		}
+
+		return http.StatusOK, nil
+	}
+	actualEvent := issueCreateLinkHandler(in)
+	expectedEvent := flyte.Event{
+		EventDef: linkEventDef,
+		Payload: linkRequest{
+			InwardIssue:  "TEST-123",
+			OutwardIssue: "Test-321",
+			LinkType:     "Depends",
+		},
+	}
+
+	if !reflect.DeepEqual(actualEvent, expectedEvent) {
+		t.Errorf("Expected: %v but got: %v", expectedEvent, actualEvent)
+	}
+}
+
+func TestLinkGetIsSuccessful(t *testing.T) {
+	initialFunc := client.SendRequest
+	defer func() { client.SendRequest = initialFunc }()
+	in := []byte(`{"linkId": "1223"}`)
+
+	expLinkId := "1223"
+	client.SendRequest = func(request *http.Request, respB interface{}) (responseCode int, err error) {
+		reqPath := request.URL.Path
+		linkId := path.Base(reqPath)
+		if linkId != expLinkId {
+			return http.StatusBadRequest, fmt.Errorf("expected issueId %s got %s", "DEVEX-553", linkId)
+		}
+
+		switch v := respB.(type) {
+		case **client.LinkIssueRequest:
+			{
+				(*v).Inward = client.LinkIssue{"TEST-123"}
+				(*v).Outward = client.LinkIssue{"TEST-321"}
+				(*v).LinkType = client.IssueLink{Name: "Depends"}
+			}
+		}
+
+		return http.StatusOK, nil
+	}
+
+	actualEvent := issueGetLinkHandler(in)
+	expectedEvent := flyte.Event{
+		EventDef: linkEventDef,
+		Payload: &client.LinkIssueRequest{
+			Inward:   client.LinkIssue{"TEST-123"},
+			Outward:  client.LinkIssue{"TEST-321"},
+			LinkType: client.IssueLink{Name: "Depends"},
+		},
+	}
+
+	if !reflect.DeepEqual(actualEvent, expectedEvent) {
+		t.Errorf("Expected: %v but got: %v", expectedEvent, actualEvent)
+	}
+}
+
+func TestLinkDeleteIsSuccessful(t *testing.T) {
+	initialFunc := client.SendRequestWithoutResp
+	defer func() { client.SendRequestWithoutResp = initialFunc }()
+	in := []byte(`{"linkId": "1223"}`)
+
+	expLinkId := "1223"
+	client.SendRequestWithoutResp = func(request *http.Request) (int, error) {
+		reqPath := request.URL.Path
+		linkId := path.Base(reqPath)
+		if linkId != expLinkId {
+			return http.StatusBadRequest, fmt.Errorf("expected issueId %s got %s", "DEVEX-553", linkId)
+		}
+
+		return http.StatusOK, nil
+	}
+
+	actualEvent := issueDeleteLinkHandler(in)
+	expectedEvent := flyte.Event{
+		EventDef: linkEventDef,
+		Payload: linkRequest{
+			LinkId: "1223",
+		},
+	}
+
+	if !reflect.DeepEqual(actualEvent, expectedEvent) {
+		t.Errorf("Expected: %v but got: %v", expectedEvent, actualEvent)
+	}
+}

--- a/domain/ticket.go
+++ b/domain/ticket.go
@@ -22,12 +22,13 @@ type Issue struct {
 }
 
 type Fields struct {
-	Summary     string   `json:"summary"`
-	Assignee    Assignee `json:"assignee"`
-	Labels      []string `json:"labels"`
-	Status      Status   `json:"status"`
-	Description string   `json:"description"`
-	Priority    Priority `json:"priority"`
+	Summary     string      `json:"summary"`
+	Assignee    Assignee    `json:"assignee"`
+	Labels      []string    `json:"labels"`
+	Status      Status      `json:"status"`
+	Description string      `json:"description"`
+	Priority    Priority    `json:"priority"`
+	Links       []IssueLink `json:"issuelinks"`
 }
 
 type Assignee struct {
@@ -45,6 +46,9 @@ type Labels struct {
 	Labels string `json:"labels"`
 }
 
+type IssueLink struct {
+	Id string `json:"id"`
+}
 type Priority struct {
 	Self    string `json:"self"`
 	IconURL string `json:"iconUrl"`

--- a/main.go
+++ b/main.go
@@ -41,6 +41,9 @@ func main() {
 			command.IssueCommentCommand,
 			command.SearchIssuesCommand,
 			command.IssueAssignCommand,
+			command.IssueCreateLinkCommand,
+			command.IssueGetLinkCommand,
+			command.IssueDeleteLinkCommand,
 		},
 	}
 


### PR DESCRIPTION
Fix #14 

* Add link capability in the form of 3 different commands that can be used: `Create`, `Get` and `Delete`.
* Added some TODOs to refactor some code (will tackle in separate PR).
* The way testing is done in most commands is not necessarily feasible and we should look at improving, most of the times we are just testing that the request is sent but not that the body of the request (or the path) have been properly created.