### PR TITLE
Adding GetTransitions Functionality

### DIFF
--- a/client/get_transitions.go
+++ b/client/get_transitions.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+type TransitionsResult struct {
+	Transitions []TransitionObj `json:"transitions"`
+}
+type TransitionObj struct {
+	TransitionId   string `json:"id"`
+	TransitionName string `json:"name"`
+}
+
+func GetTransitions(issueId string) (TransitionsResult, error) {
+	result := TransitionsResult{Transitions: []TransitionObj{}}
+	path := fmt.Sprintf("/rest/api/2/issue/%s/transitions", issueId)
+	request, err := constructGetRequest(path)
+	if err != nil {
+		return result, err
+	}
+	statusCode, err := SendRequest(request, &result)
+	if err != nil {
+		return result, err
+	}
+	if statusCode != http.StatusOK {
+		return result, errors.New("Issue does not exist")
+	}
+	return result, nil
+}

--- a/command/assign_user.go
+++ b/command/assign_user.go
@@ -2,8 +2,8 @@ package command
 
 import (
 	"encoding/json"
-	"github.com/ExpediaGroup/flyte-jira/client"
 	"github.com/ExpediaGroup/flyte-client/flyte"
+	"github.com/ExpediaGroup/flyte-jira/client"
 	"log"
 )
 
@@ -41,7 +41,7 @@ func assignIssueHandler(input json.RawMessage) flyte.Event {
 		log.Printf("Error unmarshaling Issue Assign Request [%s]: %s", input, err)
 		return newAssignFailureEvent(req, err)
 	}
-	
+
 	if err := client.AssignIssue(req.IssueId, req.Username); err != nil {
 		log.Printf("Error assigning Issue %s to User %s: %s", req.IssueId, req.Username, err)
 		return newAssignFailureEvent(req, err)

--- a/command/assign_user_test.go
+++ b/command/assign_user_test.go
@@ -3,8 +3,8 @@ package command
 import (
 	"encoding/json"
 	"errors"
-	"github.com/ExpediaGroup/flyte-jira/client"
 	"github.com/ExpediaGroup/flyte-client/flyte"
+	"github.com/ExpediaGroup/flyte-jira/client"
 	"io/ioutil"
 	"net/http"
 	"reflect"

--- a/command/comment.go
+++ b/command/comment.go
@@ -19,8 +19,8 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ExpediaGroup/flyte-jira/client"
 	"github.com/ExpediaGroup/flyte-client/flyte"
+	"github.com/ExpediaGroup/flyte-jira/client"
 	"log"
 )
 

--- a/command/create.go
+++ b/command/create.go
@@ -19,8 +19,8 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ExpediaGroup/flyte-jira/client"
 	"github.com/ExpediaGroup/flyte-client/flyte"
+	"github.com/ExpediaGroup/flyte-jira/client"
 	"log"
 )
 

--- a/command/get_transitions.go
+++ b/command/get_transitions.go
@@ -1,0 +1,68 @@
+package command
+
+import (
+	"encoding/json"
+	"github.com/ExpediaGroup/flyte-client/flyte"
+	"github.com/ExpediaGroup/flyte-jira/client"
+	"log"
+)
+
+var (
+	GetTransitions = flyte.Command{
+		Name:         "GetTransitions",
+		OutputEvents: []flyte.EventDef{getTransitionsEventDef, getTransitionsFailureEventDef},
+		Handler:      getTransitionsHandler,
+	}
+
+	getTransitionsEventDef = flyte.EventDef{
+		Name: "GetTransitions",
+	}
+
+	getTransitionsFailureEventDef = flyte.EventDef{
+		Name: "GetTransitionsFailure",
+	}
+)
+
+type issueId struct {
+	IssueId string `json:"issueId"`
+}
+
+type transitionsSuccessPayload struct {
+	Id      string                 `json:"id"`
+	Results []client.TransitionObj `json:"transitions"`
+}
+
+type transitionsFailurePayload struct {
+	Id    string `json:"id"`
+	Error string `json:"error"`
+}
+
+func getTransitionsHandler(input json.RawMessage) flyte.Event {
+	req := issueId{}
+	if err := json.Unmarshal(input, &req); err != nil {
+		log.Printf("Error unmarshaling getting transitions request [%s]: %s", input, err)
+		return getTransitionsFailureEvent(req, err)
+	}
+	results, err := client.GetTransitions(req.IssueId)
+	if err != nil {
+		log.Printf("Error getting transitions for issue %s: %s", req.IssueId, err)
+		return getTransitionsFailureEvent(req, err)
+	}
+	return flyte.Event{
+		EventDef: getTransitionsEventDef,
+		Payload: transitionsSuccessPayload{
+			Id:      req.IssueId,
+			Results: results.Transitions,
+		},
+	}
+}
+
+func getTransitionsFailureEvent(request issueId, err error) flyte.Event {
+	return flyte.Event{
+		EventDef: getTransitionsFailureEventDef,
+		Payload: transitionsFailurePayload{
+			request.IssueId,
+			err.Error(),
+		},
+	}
+}

--- a/command/get_transitions_test.go
+++ b/command/get_transitions_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright (C) 2018 Expedia Group.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	"errors"
+	"github.com/ExpediaGroup/flyte-client/flyte"
+	"github.com/ExpediaGroup/flyte-jira/client"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestGetTransitionsWorkingAsExpected(t *testing.T) {
+	initialFunc := client.SendRequest
+	defer func() { client.SendRequest = initialFunc }()
+	client.SendRequest = func(request *http.Request, responseBody interface{}) (int, error) {
+		path := request.URL.Path
+		var subStr = strings.Split(path, "/")
+		if subStr[5] != "DEVEX-567" {
+			return http.StatusNotFound, errors.New("requested jira issue not found")
+		}
+		return http.StatusOK, nil
+	}
+
+	input := []byte(`{"issueId":"DEVEX-567"}`)
+	actualEvent := getTransitionsHandler(input)
+	expectedEvent := flyte.Event{
+		EventDef: getTransitionsEventDef,
+		Payload: transitionsSuccessPayload{
+			Id:      "DEVEX-567",
+			Results: []client.TransitionObj{},
+		},
+	}
+	assert.Equal(t, expectedEvent, actualEvent)
+}
+
+func TestGetTransitionsFailure(t *testing.T) {
+	initialFunc := client.SendRequest
+	defer func() { client.SendRequest = initialFunc }()
+	client.SendRequest = func(request *http.Request, responseBody interface{}) (int, error) {
+		reqPath := request.URL.Path
+		expReqPath := "/rest/api/2/issue/DEVEX-567/transitions"
+		if reqPath != expReqPath {
+			return http.StatusNotFound, errors.New("Issue does not exist")
+		}
+		return http.StatusOK, nil
+	}
+	input := []byte(`{"issueId":"DEVEX-5677777"}`)
+	actualEvent := getTransitionsHandler(input)
+	expectedEvent := flyte.Event{
+		EventDef: getTransitionsFailureEventDef,
+		Payload: transitionsFailurePayload{
+			Id:    "DEVEX-5677777",
+			Error: "Issue does not exist",
+		},
+	}
+	assert.Equal(t, expectedEvent, actualEvent)
+}

--- a/command/get_transitions_test.go
+++ b/command/get_transitions_test.go
@@ -34,7 +34,6 @@ func TestGetTransitionsWorkingAsExpected(t *testing.T) {
 		}
 		return http.StatusOK, nil
 	}
-
 	input := []byte(`{"issueId":"DEVEX-567"}`)
 	actualEvent := getTransitionsHandler(input)
 	expectedEvent := flyte.Event{

--- a/command/info.go
+++ b/command/info.go
@@ -21,9 +21,9 @@ import (
 	"log"
 	"regexp"
 
+	"github.com/ExpediaGroup/flyte-client/flyte"
 	"github.com/ExpediaGroup/flyte-jira/client"
 	"github.com/ExpediaGroup/flyte-jira/domain"
-	"github.com/ExpediaGroup/flyte-client/flyte"
 )
 
 var (

--- a/command/issue_link.go
+++ b/command/issue_link.go
@@ -2,8 +2,8 @@ package command
 
 import (
 	"encoding/json"
-	"github.com/ExpediaGroup/flyte-jira/client"
 	"github.com/ExpediaGroup/flyte-client/flyte"
+	"github.com/ExpediaGroup/flyte-jira/client"
 	"log"
 )
 

--- a/command/issue_link_test.go
+++ b/command/issue_link_test.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ExpediaGroup/flyte-jira/client"
 	"github.com/ExpediaGroup/flyte-client/flyte"
+	"github.com/ExpediaGroup/flyte-jira/client"
 )
 
 func TestLinkCreateIsSuccessful(t *testing.T) {

--- a/command/transition.go
+++ b/command/transition.go
@@ -2,8 +2,8 @@ package command
 
 import (
 	"encoding/json"
-	"github.com/ExpediaGroup/flyte-jira/client"
 	"github.com/ExpediaGroup/flyte-client/flyte"
+	"github.com/ExpediaGroup/flyte-jira/client"
 	"log"
 )
 
@@ -62,7 +62,6 @@ func transitionHandler(input json.RawMessage) flyte.Event {
 			RequestURL:   reqURL,
 		},
 	}
-
 }
 
 func transitionFailureEvent(request transitionRequest, err error) flyte.Event {

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func main() {
 			command.IssueInfoCommand,
 			command.CreateIssueCommand,
 			command.IssueCommentCommand,
+			command.GetTransitions,
 			command.Transition,
 			command.SearchIssuesCommand,
 			command.IssueAssignCommand,


### PR DESCRIPTION
**Description:** This PR adds a new functionality to the flyte-jira pack. The new functionality is getting the transitions (statuses) for a jira issue. 

Example: if you write `jira transitions DEVEX-625` in a slack channel (that has the FlyteBot app installed) it will get you the statuses that apply for the issue DEVEX-625. In this example, it will return:

![image](https://user-images.githubusercontent.com/60599383/94798166-e63db880-03e9-11eb-8102-6ec5cb0b1fbe.png)

The documentation that is related to this change, was in this PR https://github.com/ExpediaGroup/flyte-jira/pull/23/
